### PR TITLE
Add input file path as the first argument. Ignore more directories. Python import.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.vscode/
+.idea/
+
 *.exe
 *.out

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ g++ -o options_revert.exe -O3 -s options_revert.cpp
 
 ## Usage:
 ![](https://github.com/Cracko298/MC3DS-Options-WinEdit/releases/download/v1.0.0/showoff.gif)
+### Command line
+All scripts take the input file path as the 1st argument and if it wasn't specified, it defaults to `options.txt`. Example:
+```
+options_convert my_cool_options.txt
+```

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ g++ -o options_revert.exe -O3 -s options_revert.cpp
 ```
 
 ## Usage:
-<img src="https://github.com/Cracko298/MC3DS-Options-WinEdit/releases/download/v1.0.0/showoff.gif">
+![](https://github.com/Cracko298/MC3DS-Options-WinEdit/releases/download/v1.0.0/showoff.gif)

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -26,8 +26,11 @@ void modifyFile(const std::string& filePath) {
     }
 }
 
-int main() {
+int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
+    
+    if(argc == 2) filePath = argv[1];
+
     modifyFile(filePath);
 
     return 0;

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -30,6 +30,10 @@ int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
     
     if(argc == 2) filePath = argv[1];
+    if(argc > 2){
+        std::cerr << "Too many arguments." << std::endl;
+        return 1;
+    }
 
     modifyFile(filePath);
 

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -26,8 +26,11 @@ void modifyFile(const std::string& filePath) {
     }
 }
 
-int main() {
+int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
+    
+    if(argc == 2) filePath = argv[1];
+
     modifyFile(filePath);
 
     return 0;

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -30,6 +30,10 @@ int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
     
     if(argc == 2) filePath = argv[1];
+    if(argc > 2){
+        std::cerr << "Too many arguments." << std::endl;
+        return 1;
+    }
 
     modifyFile(filePath);
 

--- a/source/py/options_converter.py
+++ b/source/py/options_converter.py
@@ -19,5 +19,8 @@ if __name__ == "__main__":
 
     if len(sys.argv) == 2:
         file_path = sys.argv[1]
+    if len(sys.argv) > 2:
+        print("Too many arguments.")
+        exit(1)
 
     modify_file(file_path)

--- a/source/py/options_converter.py
+++ b/source/py/options_converter.py
@@ -12,5 +12,6 @@ def modify_file(file_path):
         else:
             print("Target bytes not found, no modification needed.")
 
-file_path = "options.txt"
-modify_file(file_path)
+if __name__ == "__main__":
+    file_path = "options.txt"
+    modify_file(file_path)

--- a/source/py/options_converter.py
+++ b/source/py/options_converter.py
@@ -1,3 +1,5 @@
+import sys
+
 def modify_file(file_path):
     target_bytes = bytes([0xD8, 0x05, 0x20, 0x20, 0x6D, 0x70])
     with open(file_path, 'rb') as file:
@@ -14,4 +16,8 @@ def modify_file(file_path):
 
 if __name__ == "__main__":
     file_path = "options.txt"
+
+    if len(sys.argv) == 2:
+        file_path = sys.argv[1]
+
     modify_file(file_path)


### PR DESCRIPTION
All scripts can now edit files with a custom name/path specified by the user in the 1st command line argument.
The file path still defaults to `options.txt` if it wasn't specified.
If too many arguments were specified, "too many arguments" will be printed and the program will exit with code `1`.

I also made `options_converter.py` usable as a library when importing by using.
```py
if __name__ == "__main__"
```
And added `.idea` and `.vscode` directories to `.gitignore`

Cheers.