### PR TITLE
Extended CLI support

### DIFF
--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <cstdint>
 
-void modifyFile(const std::string& filePath) {
+void modifyFile(const std::string& filePath, const std::string& outputFilePath) {
     std::vector<uint8_t> targetBytes = {0xD8, 0x05, 0x20, 0x20, 0x6D, 0x70};
     std::ifstream file(filePath, std::ios::binary);
     if (file) {
@@ -14,7 +14,7 @@ void modifyFile(const std::string& filePath) {
             std::equal(targetBytes.begin(), targetBytes.end(), content.begin())) {
 
             std::replace(content.begin(), content.end(), static_cast<uint8_t>(0x20), static_cast<uint8_t>(0x00));
-            std::ofstream modifiedFile(filePath, std::ios::binary);
+            std::ofstream modifiedFile(outputFilePath, std::ios::binary);
             
             modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
             std::cout << "Modification successful." << std::endl;
@@ -28,14 +28,17 @@ void modifyFile(const std::string& filePath) {
 
 int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
-    
-    if(argc == 2) filePath = argv[1];
-    if(argc > 2){
+    std::string outputFilePath = filePath;
+
+    if(argc >= 2) filePath = argv[1];
+    if(argc == 3) outputFilePath = argv[2];
+
+    if(argc > 3){
         std::cerr << "Too many arguments." << std::endl;
         return 1;
     }
 
-    modifyFile(filePath);
+    modifyFile(filePath, outputFilePath);
 
     return 0;
 }

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -20,14 +20,14 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
                 modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
                 std::cout << "Modification successful." << std::endl;
             } else {
-                std::cerr << "Error creating output file. Check write permissions and disk space." << std::endl;
+                std::cerr << "Error creating '" << outputFilePath << "'. Check write permissions and disk space." << std::endl;
             }
-            
+
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }
     } else {
-        std::cerr << "Error opening input file. Is the path correct?" << std::endl;
+        std::cerr << "Error opening '" << filePath << "'. Is the path correct?" << std::endl;
     }
 }
 

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -22,7 +22,7 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }
     } else {
-        std::cerr << "Error opening file." << std::endl;
+        std::cerr << "Error opening input file." << std::endl;
     }
 }
 

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -3,6 +3,9 @@
 #include <vector>
 #include <algorithm>
 #include <cstdint>
+#include <string.h>
+#include <stdio.h>
+
 
 void modifyFile(const std::string& filePath, const std::string& outputFilePath) {
     std::vector<uint8_t> targetBytes = {0xD8, 0x05, 0x20, 0x20, 0x6D, 0x70};
@@ -34,6 +37,17 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
 int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
     std::string outputFilePath = filePath;
+
+    // Help text following the Unix standards.
+    if (argc == 2 && strcmp(argv[1],"--help") == 0) {
+        std::cout << "Usage: options_converter [INPUT_PATH] [OUTPUT_PATH]" << std::endl << std::endl;
+
+        std::cout << "Arguments:" << std::endl;
+        std::cout << "  INPUT_PATH    Path to the input file. Default: 'options.txt'" << std::endl;
+        std::cout << "  OUTPUT_PATH   Path to the output file. Input file will be overwritten if this argument wasn't specified." << std::endl;
+        
+        return 0;
+    }
 
     if(argc >= 2) filePath = argv[1];
     if(argc == 3) outputFilePath = argv[2];

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -15,12 +15,14 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
 
             std::replace(content.begin(), content.end(), static_cast<uint8_t>(0x20), static_cast<uint8_t>(0x00));
             std::ofstream modifiedFile(outputFilePath, std::ios::binary);
+
             if (modifiedFile) {
                 modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
                 std::cout << "Modification successful." << std::endl;
             } else {
                 std::cerr << "Error creating output file. Check write permissions and disk space." << std::endl;
             }
+            
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -50,10 +50,10 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    if(argc >= 2) filePath = argv[1];
-    if(argc == 3) outputFilePath = argv[2];
+    if (argc >= 2) filePath = argv[1];
+    if (argc == 3) outputFilePath = argv[2];
 
-    if(argc > 3){
+    if (argc > 3){
         std::cerr << "Too many arguments." << std::endl;
         return 1;
     }

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -19,7 +19,7 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
                 modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
                 std::cout << "Modification successful." << std::endl;
             } else {
-                std::cerr << "Error opening output file. Check write permissions and disk space." << std::endl;
+                std::cerr << "Error creating output file. Check write permissions and disk space." << std::endl;
             }
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -40,7 +40,8 @@ int main(int argc, char *argv[]) {
 
     // Help text following the Unix standards.
     if (argc == 2 && strcmp(argv[1],"--help") == 0) {
-        std::cout << "Usage: options_converter [INPUT_PATH] [OUTPUT_PATH]" << std::endl << std::endl;
+        std::cout << "Usage: options_converter [INPUT_PATH] [OUTPUT_PATH]" << std::endl;
+        std::cout << "Converts the options file to the 3DS format." << std::endl << std::endl;
 
         std::cout << "Arguments:" << std::endl;
         std::cout << "  INPUT_PATH    Path to the input file. Default: 'options.txt'" << std::endl;

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -19,13 +19,13 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
                 modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
                 std::cout << "Modification successful." << std::endl;
             } else {
-                std::cerr << "Error opening output file." << std::endl;
+                std::cerr << "Error opening output file. Check write permissions and disk space." << std::endl;
             }
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }
     } else {
-        std::cerr << "Error opening input file." << std::endl;
+        std::cerr << "Error opening input file. Is the path correct?" << std::endl;
     }
 }
 

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -15,9 +15,12 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
 
             std::replace(content.begin(), content.end(), static_cast<uint8_t>(0x20), static_cast<uint8_t>(0x00));
             std::ofstream modifiedFile(outputFilePath, std::ios::binary);
-            
-            modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
-            std::cout << "Modification successful." << std::endl;
+            if (modifiedFile) {
+                modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
+                std::cout << "Modification successful." << std::endl;
+            } else {
+                std::cerr << "Error opening output file." << std::endl;
+            }
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }

--- a/source/cpp/options_converter.cpp
+++ b/source/cpp/options_converter.cpp
@@ -36,7 +36,6 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
 
 int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
-    std::string outputFilePath = filePath;
 
     // Help text following the Unix standards.
     if (argc == 2 && strcmp(argv[1],"--help") == 0) {
@@ -51,6 +50,9 @@ int main(int argc, char *argv[]) {
     }
 
     if (argc >= 2) filePath = argv[1];
+
+    std::string outputFilePath = filePath;
+
     if (argc == 3) outputFilePath = argv[2];
 
     if (argc > 3){

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -20,14 +20,14 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
                 modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
                 std::cout << "Modification successful." << std::endl;
             } else {
-                std::cerr << "Error creating output file. Check write permissions and disk space." << std::endl;
+                std::cerr << "Error creating '" << outputFilePath << "'. Check write permissions and disk space." << std::endl;
             }
-            
+
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }
     } else {
-        std::cerr << "Error opening input file. Is the path correct?" << std::endl;
+        std::cerr << "Error opening '" << filePath << "'. Is the path correct?" << std::endl;
     }
 }
 

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -39,7 +39,8 @@ int main(int argc, char *argv[]) {
 
     // Help text following the Unix standards.
     if (argc == 2 && strcmp(argv[1],"--help") == 0) {
-        std::cout << "Usage: options_revert [INPUT_PATH] [OUTPUT_PATH]" << std::endl << std::endl;
+        std::cout << "Usage: options_revert [INPUT_PATH] [OUTPUT_PATH]" << std::endl;
+        std::cout << "Converts 3DS options back to the editable format." << std::endl << std::endl;
 
         std::cout << "Arguments:" << std::endl;
         std::cout << "  INPUT_PATH    Path to the input file. Default: 'options.txt'" << std::endl;

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -49,10 +49,10 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    if(argc >= 2) filePath = argv[1];
-    if(argc == 3) outputFilePath = argv[2];
+    if (argc >= 2) filePath = argv[1];
+    if (argc == 3) outputFilePath = argv[2];
 
-    if(argc > 3){
+    if (argc > 3){
         std::cerr << "Too many arguments." << std::endl;
         return 1;
     }

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <cstdint>
 
-void modifyFile(const std::string& filePath) {
+void modifyFile(const std::string& filePath, const std::string& outputFilePath) {
     std::vector<uint8_t> targetBytes = {0xD8, 0x05, 0x00, 0x00, 0x6D, 0x70};
     std::ifstream file(filePath, std::ios::binary);
     if (file) {
@@ -14,7 +14,7 @@ void modifyFile(const std::string& filePath) {
             std::equal(targetBytes.begin(), targetBytes.end(), content.begin())) {
 
             std::replace(content.begin(), content.end(), static_cast<uint8_t>(0x00), static_cast<uint8_t>(0x20));
-            std::ofstream modifiedFile(filePath, std::ios::binary);
+            std::ofstream modifiedFile(outputFilePath, std::ios::binary);
             
             modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
             std::cout << "Modification successful." << std::endl;
@@ -22,20 +22,23 @@ void modifyFile(const std::string& filePath) {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }
     } else {
-        std::cerr << "Error opening file." << std::endl;
+        std::cerr << "Error opening input file." << std::endl;
     }
 }
 
 int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
-    
-    if(argc == 2) filePath = argv[1];
-    if(argc > 2){
+    std::string outputFilePath = filePath;
+
+    if(argc >= 2) filePath = argv[1];
+    if(argc == 3) outputFilePath = argv[2];
+
+    if(argc > 3){
         std::cerr << "Too many arguments." << std::endl;
         return 1;
     }
 
-    modifyFile(filePath);
+    modifyFile(filePath, outputFilePath);
 
     return 0;
 }

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -15,12 +15,14 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
 
             std::replace(content.begin(), content.end(), static_cast<uint8_t>(0x00), static_cast<uint8_t>(0x20));
             std::ofstream modifiedFile(outputFilePath, std::ios::binary);
+
             if (modifiedFile) {
                 modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
                 std::cout << "Modification successful." << std::endl;
             } else {
                 std::cerr << "Error creating output file. Check write permissions and disk space." << std::endl;
             }
+            
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -19,7 +19,7 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
                 modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
                 std::cout << "Modification successful." << std::endl;
             } else {
-                std::cerr << "Error opening output file. Check write permissions and disk space." << std::endl;
+                std::cerr << "Error creating output file. Check write permissions and disk space." << std::endl;
             }
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -19,13 +19,13 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
                 modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
                 std::cout << "Modification successful." << std::endl;
             } else {
-                std::cerr << "Error opening output file." << std::endl;
+                std::cerr << "Error opening output file. Check write permissions and disk space." << std::endl;
             }
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }
     } else {
-        std::cerr << "Error opening input file." << std::endl;
+        std::cerr << "Error opening input file. Is the path correct?" << std::endl;
     }
 }
 

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -35,7 +35,6 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
 
 int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
-    std::string outputFilePath = filePath;
 
     // Help text following the Unix standards.
     if (argc == 2 && strcmp(argv[1],"--help") == 0) {
@@ -50,6 +49,9 @@ int main(int argc, char *argv[]) {
     }
 
     if (argc >= 2) filePath = argv[1];
+
+    std::string outputFilePath = filePath;
+
     if (argc == 3) outputFilePath = argv[2];
 
     if (argc > 3){

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -3,6 +3,8 @@
 #include <vector>
 #include <algorithm>
 #include <cstdint>
+#include <string.h>
+#include <stdio.h>
 
 void modifyFile(const std::string& filePath, const std::string& outputFilePath) {
     std::vector<uint8_t> targetBytes = {0xD8, 0x05, 0x00, 0x00, 0x6D, 0x70};
@@ -34,6 +36,17 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
 int main(int argc, char *argv[]) {
     std::string filePath = "options.txt";
     std::string outputFilePath = filePath;
+
+    // Help text following the Unix standards.
+    if (argc == 2 && strcmp(argv[1],"--help") == 0) {
+        std::cout << "Usage: options_revert [INPUT_PATH] [OUTPUT_PATH]" << std::endl << std::endl;
+
+        std::cout << "Arguments:" << std::endl;
+        std::cout << "  INPUT_PATH    Path to the input file. Default: 'options.txt'" << std::endl;
+        std::cout << "  OUTPUT_PATH   Path to the output file. Input file will be overwritten if this argument wasn't specified." << std::endl;
+        
+        return 0;
+    }
 
     if(argc >= 2) filePath = argv[1];
     if(argc == 3) outputFilePath = argv[2];

--- a/source/cpp/options_revert.cpp
+++ b/source/cpp/options_revert.cpp
@@ -15,9 +15,12 @@ void modifyFile(const std::string& filePath, const std::string& outputFilePath) 
 
             std::replace(content.begin(), content.end(), static_cast<uint8_t>(0x00), static_cast<uint8_t>(0x20));
             std::ofstream modifiedFile(outputFilePath, std::ios::binary);
-            
-            modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
-            std::cout << "Modification successful." << std::endl;
+            if (modifiedFile) {
+                modifiedFile.write(reinterpret_cast<const char*>(content.data()), content.size());
+                std::cout << "Modification successful." << std::endl;
+            } else {
+                std::cerr << "Error opening output file." << std::endl;
+            }
         } else {
             std::cout << "Target bytes not found, no modification needed." << std::endl;
         }

--- a/source/py/options_converter.py
+++ b/source/py/options_converter.py
@@ -1,6 +1,6 @@
 import sys
 
-def modify_file(file_path):
+def modify_file(file_path, output_file_path):
     target_bytes = bytes([0xD8, 0x05, 0x20, 0x20, 0x6D, 0x70])
     with open(file_path, 'rb') as file:
         content = file.read()
@@ -8,7 +8,7 @@ def modify_file(file_path):
         if content.startswith(target_bytes):
             modified_content = content.replace(b'\x20', b'\x00')
 
-            with open(file_path, 'wb') as modified_file:
+            with open(output_file_path, 'wb') as modified_file:
                 modified_file.write(modified_content)
             print("Modification successful.")
         else:
@@ -19,8 +19,10 @@ if __name__ == "__main__":
 
     if len(sys.argv) == 2:
         file_path = sys.argv[1]
-    if len(sys.argv) > 2:
-        print("Too many arguments.")
-        exit(1)
 
-    modify_file(file_path)
+    output_file_path = file_path
+
+    if len(sys.argv) == 3:
+        output_file_path = sys.argv[2]
+
+    modify_file(file_path, output_file_path)

--- a/source/py/options_converter.py
+++ b/source/py/options_converter.py
@@ -17,7 +17,7 @@ def modify_file(file_path, output_file_path):
 if __name__ == "__main__":
     file_path = "options.txt"
 
-    if len(sys.argv) == 2:
+    if len(sys.argv) >= 2:
         file_path = sys.argv[1]
 
     output_file_path = file_path

--- a/source/py/options_converter.py
+++ b/source/py/options_converter.py
@@ -25,4 +25,8 @@ if __name__ == "__main__":
     if len(sys.argv) == 3:
         output_file_path = sys.argv[2]
 
+    if len(sys.argv) > 3:
+        print("Too many arguments.")
+        exit(1)
+
     modify_file(file_path, output_file_path)


### PR DESCRIPTION
Added output file argument for all scripts. If not specified, the input file will be overwritten.

Also added a `--help` option for the C++ scripts:
`options_converter --help`
```
Usage: options_converter [INPUT_PATH] [OUTPUT_PATH]
Converts the options file to the 3DS format.

Arguments:
  INPUT_PATH    Path to the input file. Default: 'options.txt'
  OUTPUT_PATH   Path to the output file. Input file will be overwritten if this argument wasn't specified.
```
`options_revert --help`
```
Usage: options_revert [INPUT_PATH] [OUTPUT_PATH]
Converts 3DS options back to the editable format.

Arguments:
  INPUT_PATH    Path to the input file. Default: 'options.txt'
  OUTPUT_PATH   Path to the output file. Input file will be overwritten if this argument wasn't specified.
```

Error messages now provide more details such as the path and tips what could've caused the issue.

I also made some minor changes to my previous code to match your coding style.

Cheers!